### PR TITLE
Add video metadata preview and bullet summary

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -9,11 +9,36 @@ function App() {
   const [copied, setCopied] = useState(false);
   const [videoInfo, setVideoInfo] = useState(null);
 
+  const handlePreview = async () => {
+    if (!videoUrl) return;
+    try {
+      new URL(videoUrl);
+    } catch {
+      return;
+    }
+
+    try {
+      const res = await fetch('http://localhost:4000/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url: videoUrl }),
+      });
+
+      const data = await res.json();
+      if (res.ok) {
+        setVideoInfo(data.video);
+      } else {
+        setVideoInfo(null);
+      }
+    } catch {
+      // ignore connection errors for preview
+    }
+  };
+
   const handleSubmit = async (e) => {
     e.preventDefault();
     setLoading(true);
     setSummary('');
-    setVideoInfo(null);
     setError('');
     setCopied(false);
 
@@ -67,6 +92,7 @@ function App() {
           placeholder="Paste YouTube URL here"
           value={videoUrl}
           onChange={(e) => setVideoUrl(e.target.value)}
+          onBlur={handlePreview}
           required
         />
         <button type="submit" disabled={loading}>
@@ -82,7 +108,10 @@ function App() {
           <img src={videoInfo.thumbnail} alt="thumbnail" />
           <div className="video-details">
             <h2>{videoInfo.title}</h2>
-            <p>🕒 Duration: {videoInfo.duration.replace('PT', '')}</p>
+            <p>📺 {videoInfo.author}</p>
+            {videoInfo.duration && (
+              <p>🕒 Duration: {videoInfo.duration.replace('PT', '')}</p>
+            )}
           </div>
         </div>
       )}

--- a/README.md
+++ b/README.md
@@ -34,4 +34,5 @@ TLDV helps users digest long-form video content quickly by generating:
 - Paste YouTube URL
 - AI transcript summarization
 - Key takeaways with timestamp support
+- Video metadata preview (title, channel, thumbnail)
 - Error handling and loading state


### PR DESCRIPTION
## Summary
- better bullet-format summary instructions
- add preview endpoint in backend
- fetch and return video metadata
- show YouTube metadata preview in the frontend
- update docs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683fe343a7bc8328a460dfc2026d3429