### PR TITLE
Add localStorage for past summaries

### DIFF
--- a/App.css
+++ b/App.css
@@ -91,3 +91,29 @@ button {
   color: #bbb;
   margin-top: 4px;
 }
+
+.past-summaries {
+  margin-top: 30px;
+}
+
+.past-summary-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px;
+  background: #252525;
+  border-radius: 6px;
+  margin-bottom: 10px;
+}
+
+.past-summary-item a {
+  color: #646cff;
+  word-break: break-all;
+}
+
+.past-date {
+  display: block;
+  color: #bbb;
+  margin-top: 4px;
+  font-size: 0.9rem;
+}

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,10 @@
+export function formatTimestamp(ts) {
+  const date = new Date(ts);
+  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+  const m = months[date.getMonth()];
+  const d = date.getDate();
+  const y = date.getFullYear();
+  const hh = String(date.getHours()).padStart(2, '0');
+  const mm = String(date.getMinutes()).padStart(2, '0');
+  return `${m} ${d}, ${y} – ${hh}:${mm}`;
+}


### PR DESCRIPTION
## Summary
- save generated summaries to localStorage and keep last 10 entries
- load past summaries on startup and show them below current summary
- allow viewing an old summary
- basic styling for history list
- utility to format timestamps

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683fe6dd52c08328b1b6a1e09eaac84b