### PR TITLE
Add download & friendly video error

### DIFF
--- a/App.css
+++ b/App.css
@@ -91,3 +91,12 @@ button {
   color: #bbb;
   margin-top: 4px;
 }
+
+/* download buttons inside the summary box */
+.download-btn {
+  background: #3a3a3a;
+}
+
+.download-btn:hover {
+  background: #4e4e4e;
+}

--- a/App.jsx
+++ b/App.jsx
@@ -41,7 +41,8 @@ function App() {
   };
 
   const downloadFile = (ext) => {
-    const blob = new Blob([summary], { type: 'text/plain;charset=utf-8' });
+    const mime = ext === 'md' ? 'text/markdown' : 'text/plain';
+    const blob = new Blob([summary], { type: `${mime};charset=utf-8` });
     const link = document.createElement('a');
     link.href = URL.createObjectURL(blob);
     link.download = `summary.${ext}`;
@@ -92,8 +93,12 @@ function App() {
           <h2>Summary</h2>
           <div className="summary-text">{summary}</div>
           <div className="buttons">
-            <button onClick={() => downloadFile('txt')}>⬇️ Export .txt</button>
-            <button onClick={() => downloadFile('md')}>⬇️ Export .md</button>
+            <button className="download-btn" onClick={() => downloadFile('txt')}>
+              ⬇️ Download TXT
+            </button>
+            <button className="download-btn" onClick={() => downloadFile('md')}>
+              ⬇️ Download MD
+            </button>
             <button onClick={copyToClipboard}>📋 Copy to Clipboard</button>
             {copied && <span className="copied-msg">✅ Copied!</span>}
           </div>

--- a/app.js
+++ b/app.js
@@ -57,9 +57,10 @@ app.post("/summarize", async (req, res) => {
   try {
     transcriptText = await fetchAnyTranscript(videoId);
   } catch (err) {
-    return res
-      .status(400)
-      .json({ error: "No transcript available for this video." });
+    console.error("Transcript fetch error:", err);
+    return res.status(400).json({
+      error: "\u26A0\uFE0F Transcript not found or video is private.",
+    });
   }
 
   // 2) Send it to OpenAI for summarization


### PR DESCRIPTION
## Summary
- offer MD and TXT downloads for each summary
- tweak styles for new download buttons
- return clearer error for missing/private videos

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683fe6285784832880a75f85b0db5f28