### PR TITLE
Fix OpenAI model and ESLint config

### DIFF
--- a/app.js
+++ b/app.js
@@ -73,7 +73,8 @@ app.post("/summarize", async (req, res) => {
     // 2) Send to OpenAI for summarization
     console.log('Sending to OpenAI for summarization...');
     const completion = await openai.chat.completions.create({
-      model: "gpt-4o-mini", // Using more cost-effective model
+      // Use the latest cost-effective GPT-4 Turbo model
+      model: "gpt-4o",
       messages: [
         {
           role: "system",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,14 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 export default [
   { ignores: ['dist'] },
   {
+    files: ['app.js'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: globals.node,
+    },
+  },
+  {
     files: ['**/*.{js,jsx}'],
     languageOptions: {
       ecmaVersion: 2020,


### PR DESCRIPTION
## Summary
- use `gpt-4o` model instead of invalid `gpt-4o-mini`
- configure ESLint with Node globals for `app.js`

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68407e27c37c8328a4cbcda8c398d222